### PR TITLE
Number of bars now adjustable from plugin config window

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Musical Spectrum plugin for DeaDBeeF audio player
 ====================
 
-This plugin is based on DeaDBeeFs stock spectrum. It currently offers more accuracy (FFT size 8192) and the bars are layed out to represent the musical keys. In the future I will add more features like select FFT size, display music keys or frequencies - basically most of what [foo_musical_spectrum](http://wiki.hydrogenaudio.org/index.php?title=Foobar2000:Components/Musical_Spectrum_%28foo_musical_spectrum%29) already does. 
+This plugin is based on DeaDBeeFs stock spectrum. It offers variable FFT size (up to 32768), Blackmann-Harris and Hanning window functions, and various eye candy options.
 
 ## Installation
 

--- a/config.c
+++ b/config.c
@@ -38,6 +38,7 @@ int CONFIG_GRADIENT_ORIENTATION = 0;
 int CONFIG_NUM_COLORS = 6;
 int CONFIG_FFT_SIZE = 8192;
 int CONFIG_WINDOW = 0;
+int CONFIG_NUM_BARS = 126;
 GdkColor CONFIG_COLOR_BG;
 GdkColor CONFIG_COLOR_VGRID;
 GdkColor CONFIG_COLOR_HGRID;
@@ -65,6 +66,7 @@ save_config (void)
     deadbeef->conf_set_int (CONFSTR_MS_ENABLE_VGRID,                CONFIG_ENABLE_VGRID);
     deadbeef->conf_set_int (CONFSTR_MS_ALIGNMENT,                   CONFIG_ALIGNMENT);
     deadbeef->conf_set_int (CONFSTR_MS_ENABLE_BAR_MODE,             CONFIG_ENABLE_BAR_MODE);
+    deadbeef->conf_set_int (CONFSTR_MS_NUM_BARS,                    CONFIG_NUM_BARS);
     deadbeef->conf_set_int (CONFSTR_MS_BAR_FALLOFF,                 CONFIG_BAR_FALLOFF);
     deadbeef->conf_set_int (CONFSTR_MS_BAR_DELAY,                   CONFIG_BAR_DELAY);
     deadbeef->conf_set_int (CONFSTR_MS_PEAK_FALLOFF,                CONFIG_PEAK_FALLOFF);
@@ -101,6 +103,7 @@ load_config (void)
     CONFIG_ALIGNMENT = deadbeef->conf_get_int (CONFSTR_MS_ALIGNMENT,                      LEFT);
     CONFIG_ENABLE_BAR_MODE = deadbeef->conf_get_int (CONFSTR_MS_ENABLE_BAR_MODE,             0);
     CONFIG_REFRESH_INTERVAL = deadbeef->conf_get_int (CONFSTR_MS_REFRESH_INTERVAL,          25);
+    CONFIG_NUM_BARS = deadbeef->conf_get_int (CONFSTR_MS_NUM_BARS,                         126);
     CONFIG_BAR_FALLOFF = deadbeef->conf_get_int (CONFSTR_MS_BAR_FALLOFF,                    -1);
     CONFIG_BAR_DELAY = deadbeef->conf_get_int (CONFSTR_MS_BAR_DELAY,                         0);
     CONFIG_PEAK_FALLOFF = deadbeef->conf_get_int (CONFSTR_MS_PEAK_FALLOFF,                  90);

--- a/config.c
+++ b/config.c
@@ -39,6 +39,7 @@ int CONFIG_NUM_COLORS = 6;
 int CONFIG_FFT_SIZE = 8192;
 int CONFIG_WINDOW = 0;
 int CONFIG_NUM_BARS = 126;
+int CONFIG_GAPS = TRUE;
 GdkColor CONFIG_COLOR_BG;
 GdkColor CONFIG_COLOR_VGRID;
 GdkColor CONFIG_COLOR_HGRID;
@@ -67,6 +68,7 @@ save_config (void)
     deadbeef->conf_set_int (CONFSTR_MS_ALIGNMENT,                   CONFIG_ALIGNMENT);
     deadbeef->conf_set_int (CONFSTR_MS_ENABLE_BAR_MODE,             CONFIG_ENABLE_BAR_MODE);
     deadbeef->conf_set_int (CONFSTR_MS_NUM_BARS,                    CONFIG_NUM_BARS);
+    deadbeef->conf_set_int (CONFSTR_MS_GAPS,                        CONFIG_GAPS);
     deadbeef->conf_set_int (CONFSTR_MS_BAR_FALLOFF,                 CONFIG_BAR_FALLOFF);
     deadbeef->conf_set_int (CONFSTR_MS_BAR_DELAY,                   CONFIG_BAR_DELAY);
     deadbeef->conf_set_int (CONFSTR_MS_PEAK_FALLOFF,                CONFIG_PEAK_FALLOFF);
@@ -104,6 +106,7 @@ load_config (void)
     CONFIG_ENABLE_BAR_MODE = deadbeef->conf_get_int (CONFSTR_MS_ENABLE_BAR_MODE,             0);
     CONFIG_REFRESH_INTERVAL = deadbeef->conf_get_int (CONFSTR_MS_REFRESH_INTERVAL,          25);
     CONFIG_NUM_BARS = deadbeef->conf_get_int (CONFSTR_MS_NUM_BARS,                         126);
+    CONFIG_GAPS = deadbeef->conf_get_int (CONFSTR_MS_GAPS,                                TRUE);
     CONFIG_BAR_FALLOFF = deadbeef->conf_get_int (CONFSTR_MS_BAR_FALLOFF,                    -1);
     CONFIG_BAR_DELAY = deadbeef->conf_get_int (CONFSTR_MS_BAR_DELAY,                         0);
     CONFIG_PEAK_FALLOFF = deadbeef->conf_get_int (CONFSTR_MS_PEAK_FALLOFF,                  90);

--- a/config.h
+++ b/config.h
@@ -43,6 +43,7 @@
 #define     CONFSTR_MS_ENABLE_HGRID           "musical_spectrum.enable_hgrid"
 #define     CONFSTR_MS_ENABLE_VGRID           "musical_spectrum.enable_vgrid"
 #define     CONFSTR_MS_ENABLE_BAR_MODE        "musical_spectrum.enable_bar_mode"
+#define     CONFSTR_MS_NUM_BARS               "musical_spectrum.num_bars"
 #define     CONFSTR_MS_BAR_FALLOFF            "musical_spectrum.bar_falloff"
 #define     CONFSTR_MS_BAR_DELAY              "musical_spectrum.bar_delay"
 #define     CONFSTR_MS_PEAK_FALLOFF           "musical_spectrum.peak_falloff"
@@ -73,6 +74,7 @@ extern int CONFIG_GRADIENT_ORIENTATION;
 extern int CONFIG_NUM_COLORS;
 extern int CONFIG_FFT_SIZE;
 extern int CONFIG_WINDOW;
+extern int CONFIG_NUM_BARS;
 extern GdkColor CONFIG_COLOR_BG;
 extern GdkColor CONFIG_COLOR_VGRID;
 extern GdkColor CONFIG_COLOR_HGRID;

--- a/config.h
+++ b/config.h
@@ -44,6 +44,7 @@
 #define     CONFSTR_MS_ENABLE_VGRID           "musical_spectrum.enable_vgrid"
 #define     CONFSTR_MS_ENABLE_BAR_MODE        "musical_spectrum.enable_bar_mode"
 #define     CONFSTR_MS_NUM_BARS               "musical_spectrum.num_bars"
+#define     CONFSTR_MS_GAPS                   "musical_spectrum.gaps"
 #define     CONFSTR_MS_BAR_FALLOFF            "musical_spectrum.bar_falloff"
 #define     CONFSTR_MS_BAR_DELAY              "musical_spectrum.bar_delay"
 #define     CONFSTR_MS_PEAK_FALLOFF           "musical_spectrum.peak_falloff"
@@ -75,6 +76,7 @@ extern int CONFIG_NUM_COLORS;
 extern int CONFIG_FFT_SIZE;
 extern int CONFIG_WINDOW;
 extern int CONFIG_NUM_BARS;
+extern int CONFIG_GAPS;
 extern GdkColor CONFIG_COLOR_BG;
 extern GdkColor CONFIG_COLOR_VGRID;
 extern GdkColor CONFIG_COLOR_HGRID;

--- a/spectrum.c
+++ b/spectrum.c
@@ -472,7 +472,13 @@ spectrum_motion_notify_event (GtkWidget *widget, GdkEventButton *event, gpointer
     GtkAllocation a;
     gtk_widget_get_allocation (widget, &a);
 
-    const int barw = CLAMP (a.width / CONFIG_NUM_BARS, 2, 20);
+    int barw;
+
+    if (CONFIG_GAPS)
+        barw = CLAMP (a.width / CONFIG_NUM_BARS, 2, 20);
+    else
+        barw = CLAMP (a.width / CONFIG_NUM_BARS, 2, 20) - 1;
+
     int left = 0;
     switch (CONFIG_ALIGNMENT) {
         case LEFT:

--- a/spectrum.c
+++ b/spectrum.c
@@ -648,8 +648,8 @@ musical_spectrum_disconnect (void)
 
 static const char settings_dlg[] =
     "property \"Refresh interval (ms): \"       spinbtn[10,1000,1] "        CONFSTR_MS_REFRESH_INTERVAL         " 25 ;\n"
-    "property \"Number of bars \"               spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 126 ;\n"
-    "property \"Gap between bars: \"            checkbox "                  CONFSTR_MS_GAPS                     " 1 ;\n"
+    "property \"Number of bars: \"              spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 126 ;\n"
+    "property \"Gap between bars  \"            checkbox "                  CONFSTR_MS_GAPS                     " 1 ;\n"
     "property \"Bar falloff (dB/s): \"          spinbtn[-1,1000,1] "        CONFSTR_MS_BAR_FALLOFF              " -1 ;\n"
     "property \"Bar delay (ms): \"              spinbtn[0,10000,100] "      CONFSTR_MS_BAR_DELAY                " 0 ;\n"
     "property \"Peak falloff (dB/s): \"         spinbtn[-1,1000,1] "        CONFSTR_MS_PEAK_FALLOFF             " 90 ;\n"

--- a/spectrum.c
+++ b/spectrum.c
@@ -181,13 +181,13 @@ spectrum_interpolate (gpointer user_data, int bands, int index)
 
         // find index of next value
         int j = 0;
-        while (index+j < MAX_BANDS && w->keys[index+j] == w->keys[index]) {
+        while (index+j < CONFIG_NUM_BARS && w->keys[index+j] == w->keys[index]) {
             j++;
         }
         const float v2 = 10 * log10 (w->data[w->keys[index+j]]);
 
         int l = j;
-        while (index+l < MAX_BANDS && w->keys[index+l] == w->keys[index+j]) {
+        while (index+l < CONFIG_NUM_BARS && w->keys[index+l] == w->keys[index+j]) {
             l++;
         }
         const float v3 = 10 * log10 (w->data[w->keys[index+l]]);
@@ -233,7 +233,7 @@ spectrum_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data) {
     GtkAllocation a;
     gtk_widget_get_allocation (widget, &a);
 
-    const int bands = MAX_BANDS;
+    const int bands = CONFIG_NUM_BARS;
     const int width = a.width;
     const int height = a.height;
 
@@ -459,27 +459,28 @@ spectrum_motion_notify_event (GtkWidget *widget, GdkEventButton *event, gpointer
     GtkAllocation a;
     gtk_widget_get_allocation (widget, &a);
 
-    const int barw = CLAMP (a.width / MAX_BANDS, 2, 20);
+    const int barw = CLAMP (a.width / CONFIG_NUM_BARS, 2, 20);
     int left = 0;
     switch (CONFIG_ALIGNMENT) {
         case LEFT:
             left = 0;
             break;
         case RIGHT:
-            left = MIN (a.width, a.width - (barw * MAX_BANDS));
+            left = MIN (a.width, a.width - (barw * CONFIG_NUM_BARS));
             break;
         case CENTER:
-            left = MAX (0, (a.width - (barw * MAX_BANDS))/2);
+            left = MAX (0, (a.width - (barw * CONFIG_NUM_BARS))/2);
             break;
         default:
             left = 0;
             break;
     }
 
-    if (event->x > left && event->x < left + barw * MAX_BANDS) {
-        int pos = CLAMP ((int)((event->x-1-left)/barw),0,MAX_BANDS-1);
+    if (event->x > left && event->x < left + barw * CONFIG_NUM_BARS) {
+        int pos = CLAMP ((int)((event->x-1-left)/barw),0,CONFIG_NUM_BARS-1);
+        int npos = ftoi( pos * 126 / CONFIG_NUM_BARS );
         char tooltip_text[20];
-        snprintf (tooltip_text, sizeof (tooltip_text), "%5.0f Hz (%s)", w->freq[pos], notes[pos]);
+        snprintf (tooltip_text, sizeof (tooltip_text), "%5.0f Hz (%s)", w->freq[pos], notes[npos]);
         gtk_widget_set_tooltip_text (widget, tooltip_text);
         return TRUE;
     }
@@ -634,6 +635,7 @@ musical_spectrum_disconnect (void)
 
 static const char settings_dlg[] =
     "property \"Refresh interval (ms): \"           spinbtn[10,1000,1] "      CONFSTR_MS_REFRESH_INTERVAL         " 25 ;\n"
+    "property \"Number of bars: \"           spinbtn[2,2000,1] "      CONFSTR_MS_NUM_BARS         " 126 ;\n"
     "property \"Bar falloff (dB/s): \"           spinbtn[-1,1000,1] "      CONFSTR_MS_BAR_FALLOFF         " -1 ;\n"
     "property \"Bar delay (ms): \"                spinbtn[0,10000,100] "      CONFSTR_MS_BAR_DELAY           " 0 ;\n"
     "property \"Peak falloff (dB/s): \"          spinbtn[-1,1000,1] "      CONFSTR_MS_PEAK_FALLOFF        " 90 ;\n"

--- a/spectrum.c
+++ b/spectrum.c
@@ -648,7 +648,7 @@ musical_spectrum_disconnect (void)
 
 static const char settings_dlg[] =
     "property \"Refresh interval (ms): \"       spinbtn[10,1000,1] "        CONFSTR_MS_REFRESH_INTERVAL         " 25 ;\n"
-    "property \"Number of bars: \"              spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 126 ;\n"
+    "property \"Number of bars \"               spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 126 ;\n"
     "property \"Gap between bars: \"            checkbox "                  CONFSTR_MS_GAPS                     " 1 ;\n"
     "property \"Bar falloff (dB/s): \"          spinbtn[-1,1000,1] "        CONFSTR_MS_BAR_FALLOFF              " -1 ;\n"
     "property \"Bar delay (ms): \"              spinbtn[0,10000,100] "      CONFSTR_MS_BAR_DELAY                " 0 ;\n"

--- a/spectrum.c
+++ b/spectrum.c
@@ -322,7 +322,13 @@ spectrum_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data) {
     const int stride = cairo_image_surface_get_stride (w->surf);
     memset (data, 0, a.height * stride);
 
-    const int barw = CLAMP (width / bands, 2, 20);
+    int barw;
+
+    if (CONFIG_GAPS)
+        barw = CLAMP (width / bands, 2, 20);
+    else
+        barw = CLAMP (width / bands, 2, 20) - 1;
+
     int left = 0;
     switch (CONFIG_ALIGNMENT) {
         case LEFT:
@@ -364,7 +370,14 @@ spectrum_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data) {
         if (y < 0) {
             y = 0;
         }
-        int bw = barw-1;
+
+        int bw;
+
+        if (CONFIG_GAPS)
+            bw = barw -1;
+        else
+            bw = barw;
+
         if (x + bw >= a.width) {
             bw = a.width-x-1;
         }
@@ -634,12 +647,13 @@ musical_spectrum_disconnect (void)
 }
 
 static const char settings_dlg[] =
-    "property \"Refresh interval (ms): \"           spinbtn[10,1000,1] "      CONFSTR_MS_REFRESH_INTERVAL         " 25 ;\n"
-    "property \"Number of bars: \"           spinbtn[2,2000,1] "      CONFSTR_MS_NUM_BARS         " 126 ;\n"
-    "property \"Bar falloff (dB/s): \"           spinbtn[-1,1000,1] "      CONFSTR_MS_BAR_FALLOFF         " -1 ;\n"
-    "property \"Bar delay (ms): \"                spinbtn[0,10000,100] "      CONFSTR_MS_BAR_DELAY           " 0 ;\n"
-    "property \"Peak falloff (dB/s): \"          spinbtn[-1,1000,1] "      CONFSTR_MS_PEAK_FALLOFF        " 90 ;\n"
-    "property \"Peak delay (ms): \"               spinbtn[0,10000,100] "      CONFSTR_MS_PEAK_DELAY          " 500 ;\n"
+    "property \"Refresh interval (ms): \"       spinbtn[10,1000,1] "        CONFSTR_MS_REFRESH_INTERVAL         " 25 ;\n"
+    "property \"Number of bars: \"              spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 126 ;\n"
+    "property \"Gap between bars: \"            checkbox "                  CONFSTR_MS_GAPS                     " 1 ;\n"
+    "property \"Bar falloff (dB/s): \"          spinbtn[-1,1000,1] "        CONFSTR_MS_BAR_FALLOFF              " -1 ;\n"
+    "property \"Bar delay (ms): \"              spinbtn[0,10000,100] "      CONFSTR_MS_BAR_DELAY                " 0 ;\n"
+    "property \"Peak falloff (dB/s): \"         spinbtn[-1,1000,1] "        CONFSTR_MS_PEAK_FALLOFF             " 90 ;\n"
+    "property \"Peak delay (ms): \"             spinbtn[0,10000,100] "      CONFSTR_MS_PEAK_DELAY               " 500 ;\n"
 ;
 
 DB_misc_t plugin = {

--- a/spectrum.h
+++ b/spectrum.h
@@ -30,7 +30,9 @@
 #include <deadbeef/deadbeef.h>
 #include <deadbeef/gtkui_api.h>
 
-#define MAX_BANDS 126
+#include "config.h"
+
+#define MAX_BARS 2000
 #define REFRESH_INTERVAL 25
 #define GRADIENT_TABLE_SIZE 1024
 #define MAX_FFT_SIZE 32768
@@ -51,9 +53,9 @@ typedef struct {
     double *data;
     double window[MAX_FFT_SIZE];
     // keys: index of frequencies of musical notes (c0;d0;...;f10) in data
-    int keys[MAX_BANDS + 1];
+    int keys[MAX_BARS + 1];
     // freq: hold frequency values
-    float freq[MAX_BANDS + 1];
+    float freq[MAX_BARS + 1];
     uint32_t colors[GRADIENT_TABLE_SIZE];
     int samplerate;
     double *samples;
@@ -62,10 +64,10 @@ typedef struct {
     fftw_plan p_r2c;
     int buffered;
     int low_res_end;
-    float bars[MAX_BANDS + 1];
-    int delay[MAX_BANDS + 1];
-    float peaks[MAX_BANDS + 1];
-    int delay_peak[MAX_BANDS + 1];
+    float bars[MAX_BARS + 1];
+    int delay[MAX_BARS + 1];
+    float peaks[MAX_BARS + 1];
+    int delay_peak[MAX_BARS + 1];
     intptr_t mutex;
 } w_spectrum_t;
 

--- a/spectrum.h
+++ b/spectrum.h
@@ -30,8 +30,6 @@
 #include <deadbeef/deadbeef.h>
 #include <deadbeef/gtkui_api.h>
 
-#include "config.h"
-
 #define MAX_BARS 2000
 #define REFRESH_INTERVAL 25
 #define GRADIENT_TABLE_SIZE 1024

--- a/utils.c
+++ b/utils.c
@@ -35,17 +35,17 @@
 #include "spectrum.h"
 
 char *notes[] = {"C0","C#0","D0","D#0","E0","F0","F#0","G0","G#0","A0","A#0","B0",
-                        "C1","C#1","D1","D#1","E1","F1","F#1","G1","G#1","A1","A#1","B1",
-                        "C2","C#2","D2","D#2","E2","F2","F#2","G2","G#2","A2","A#2","B2",
-                        "C3","C#3","D3","D#3","E3","F3","F#3","G3","G#3","A3","A#3","B3",
-                        "C4","C#4","D4","D#4","E4","F4","F#4","G4","G#4","A4","A#4","B4",
-                        "C5","C#5","D5","D#5","E5","F5","F#5","G5","G#5","A5","A#5","B5",
-                        "C6","C#6","D6","D#6","E6","F6","F#6","G6","G#6","A6","A#6","B6",
-                        "C7","C#7","D7","D#7","E7","F7","F#7","G7","G#7","A7","A#7","B7",
-                        "C8","C#8","D8","D#8","E8","F8","F#8","G8","G#8","A8","A#8","B8",
-                        "C9","C#9","D9","D#9","E9","F9","F#9","G9","G#9","A9","A#9","B9",
-                        "C10","C#10","D10","D#10","E10","F10","F#10","G10","G#10","A10","A#10","B10"
-                       };
+                    "C1","C#1","D1","D#1","E1","F1","F#1","G1","G#1","A1","A#1","B1",
+                    "C2","C#2","D2","D#2","E2","F2","F#2","G2","G#2","A2","A#2","B2",
+                    "C3","C#3","D3","D#3","E3","F3","F#3","G3","G#3","A3","A#3","B3",
+                    "C4","C#4","D4","D#4","E4","F4","F#4","G4","G#4","A4","A#4","B4",
+                    "C5","C#5","D5","D#5","E5","F5","F#5","G5","G#5","A5","A#5","B5",
+                    "C6","C#6","D6","D#6","E6","F6","F#6","G6","G#6","A6","A#6","B6",
+                    "C7","C#7","D7","D#7","E7","F7","F#7","G7","G#7","A7","A#7","B7",
+                    "C8","C#8","D8","D#8","E8","F8","F#8","G8","G#8","A8","A#8","B8",
+                    "C9","C#9","D9","D#9","E9","F9","F#9","G9","G#9","A9","A#9","B9",
+                    "C10","C#10","D10","D#10","E10","F10","F#10","G10","G#10","A10","A#10","B10"
+                };
 
 void
 _memset_pattern (char *data, const void* pattern, size_t data_len, size_t pattern_len)
@@ -138,14 +138,18 @@ create_frequency_table (gpointer user_data)
     w_spectrum_t *w = user_data;
 
     w->low_res_end = 0;
-    for (int i = 0; i < MAX_BANDS; i++) {
-        w->freq[i] = 440.0 * pow (2.0, (double)(i-57)/12.0);
+
+    double ratio = CONFIG_NUM_BARS / 126.0;
+    double a4pos = 57.0 * ratio;
+    double octave = 12.0 * ratio;
+
+    for (int i = 0; i < CONFIG_NUM_BARS; i++) {
+        w->freq[i] = 440.0 * pow (2.0, (double)(i-a4pos)/octave);
         w->keys[i] = ftoi (w->freq[i] * CONFIG_FFT_SIZE/(float)w->samplerate);
         if (i > 0 && w->keys[i-1] == w->keys[i])
             w->low_res_end = i;
     }
 }
-
 float
 linear_interpolate (float y1, float y2, float mu)
 {
@@ -161,4 +165,3 @@ lagrange_interpolate (float y0, float y1, float y2, float y3, float x)
     const float a3 = ((x - 0) * (x - 1) * (x - 2)) /  6 * y3;
     return (a0 + a1 + a2 + a3);
 }
-


### PR DESCRIPTION
Adds an option in the Preferences->Plugins->Musical Spectrum->Configure window. Defaults to 126 to correspond to keys as intended. When changed, tooltips still display proper key.