### PR TITLE
Bar width can be set manually

### DIFF
--- a/config.c
+++ b/config.c
@@ -49,7 +49,7 @@ int CONFIG_GRADIENT_ORIENTATION = 0;
 int CONFIG_NUM_COLORS = 6;
 int CONFIG_FFT_SIZE = 8192;
 int CONFIG_WINDOW = 0;
-int CONFIG_NUM_BARS = 131;
+int CONFIG_NUM_BARS = 132;
 int CONFIG_BAR_W = TRUE;
 int CONFIG_GAPS = TRUE;
 GdkColor CONFIG_COLOR_BG;
@@ -118,7 +118,7 @@ load_config (void)
     CONFIG_ALIGNMENT = deadbeef->conf_get_int (CONFSTR_MS_ALIGNMENT,                      LEFT);
     CONFIG_ENABLE_BAR_MODE = deadbeef->conf_get_int (CONFSTR_MS_ENABLE_BAR_MODE,             0);
     CONFIG_REFRESH_INTERVAL = deadbeef->conf_get_int (CONFSTR_MS_REFRESH_INTERVAL,          25);
-    CONFIG_NUM_BARS = deadbeef->conf_get_int (CONFSTR_MS_NUM_BARS,                         131);
+    CONFIG_NUM_BARS = deadbeef->conf_get_int (CONFSTR_MS_NUM_BARS,                         132);
     CONFIG_BAR_W = deadbeef->conf_get_int (CONFSTR_MS_BAR_W,                                 1);
     CONFIG_GAPS = deadbeef->conf_get_int (CONFSTR_MS_GAPS,                                TRUE);
     CONFIG_BAR_FALLOFF = deadbeef->conf_get_int (CONFSTR_MS_BAR_FALLOFF,                    -1);

--- a/config.c
+++ b/config.c
@@ -49,7 +49,8 @@ int CONFIG_GRADIENT_ORIENTATION = 0;
 int CONFIG_NUM_COLORS = 6;
 int CONFIG_FFT_SIZE = 8192;
 int CONFIG_WINDOW = 0;
-int CONFIG_NUM_BARS = 126;
+int CONFIG_NUM_BARS = 131;
+int CONFIG_BAR_W = TRUE;
 int CONFIG_GAPS = TRUE;
 GdkColor CONFIG_COLOR_BG;
 GdkColor CONFIG_COLOR_VGRID;
@@ -79,6 +80,7 @@ save_config (void)
     deadbeef->conf_set_int (CONFSTR_MS_ALIGNMENT,                   CONFIG_ALIGNMENT);
     deadbeef->conf_set_int (CONFSTR_MS_ENABLE_BAR_MODE,             CONFIG_ENABLE_BAR_MODE);
     deadbeef->conf_set_int (CONFSTR_MS_NUM_BARS,                    CONFIG_NUM_BARS);
+    deadbeef->conf_set_int (CONFSTR_MS_BAR_W,                       CONFIG_BAR_W);
     deadbeef->conf_set_int (CONFSTR_MS_GAPS,                        CONFIG_GAPS);
     deadbeef->conf_set_int (CONFSTR_MS_BAR_FALLOFF,                 CONFIG_BAR_FALLOFF);
     deadbeef->conf_set_int (CONFSTR_MS_BAR_DELAY,                   CONFIG_BAR_DELAY);
@@ -116,7 +118,8 @@ load_config (void)
     CONFIG_ALIGNMENT = deadbeef->conf_get_int (CONFSTR_MS_ALIGNMENT,                      LEFT);
     CONFIG_ENABLE_BAR_MODE = deadbeef->conf_get_int (CONFSTR_MS_ENABLE_BAR_MODE,             0);
     CONFIG_REFRESH_INTERVAL = deadbeef->conf_get_int (CONFSTR_MS_REFRESH_INTERVAL,          25);
-    CONFIG_NUM_BARS = deadbeef->conf_get_int (CONFSTR_MS_NUM_BARS,                         126);
+    CONFIG_NUM_BARS = deadbeef->conf_get_int (CONFSTR_MS_NUM_BARS,                         131);
+    CONFIG_BAR_W = deadbeef->conf_get_int (CONFSTR_MS_BAR_W,                                 1);
     CONFIG_GAPS = deadbeef->conf_get_int (CONFSTR_MS_GAPS,                                TRUE);
     CONFIG_BAR_FALLOFF = deadbeef->conf_get_int (CONFSTR_MS_BAR_FALLOFF,                    -1);
     CONFIG_BAR_DELAY = deadbeef->conf_get_int (CONFSTR_MS_BAR_DELAY,                         0);

--- a/config.h
+++ b/config.h
@@ -32,6 +32,7 @@
 #define     CONFSTR_MS_ENABLE_VGRID           "musical_spectrum.enable_vgrid"
 #define     CONFSTR_MS_ENABLE_BAR_MODE        "musical_spectrum.enable_bar_mode"
 #define     CONFSTR_MS_NUM_BARS               "musical_spectrum.num_bars"
+#define     CONFSTR_MS_BAR_W                  "musical_spectrum.bar_w"
 #define     CONFSTR_MS_GAPS                   "musical_spectrum.gaps"
 #define     CONFSTR_MS_BAR_FALLOFF            "musical_spectrum.bar_falloff"
 #define     CONFSTR_MS_BAR_DELAY              "musical_spectrum.bar_delay"
@@ -64,6 +65,7 @@ extern int CONFIG_NUM_COLORS;
 extern int CONFIG_FFT_SIZE;
 extern int CONFIG_WINDOW;
 extern int CONFIG_NUM_BARS;
+extern int CONFIG_BAR_W;
 extern int CONFIG_GAPS;
 extern GdkColor CONFIG_COLOR_BG;
 extern GdkColor CONFIG_COLOR_VGRID;

--- a/spectrum.c
+++ b/spectrum.c
@@ -263,8 +263,10 @@ spectrum_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data) {
     if (!w->samples) {
         return FALSE;
     }
+    create_frequency_table(w);
+
     GtkAllocation a;
-    gtk_widget_get_allocation (widget, &a);
+    gtk_widget_get_allocation (w->drawarea, &a);
 
     const int bands = CONFIG_NUM_BARS;
     const int width = a.width;
@@ -504,7 +506,7 @@ spectrum_motion_notify_event (GtkWidget *widget, GdkEventButton *event, gpointer
 
     if (event->x > left && event->x < left + barw * CONFIG_NUM_BARS) {
         int pos = CLAMP ((int)((event->x-1-left)/barw),0,CONFIG_NUM_BARS-1);
-        int npos = ftoi( pos * 126 / CONFIG_NUM_BARS );
+        int npos = ftoi( pos * 131 / CONFIG_NUM_BARS );
         char tooltip_text[20];
         snprintf (tooltip_text, sizeof (tooltip_text), "%5.0f Hz (%s)", w->freq[pos], notes[npos]);
         gtk_widget_set_tooltip_text (widget, tooltip_text);
@@ -671,7 +673,8 @@ musical_spectrum_disconnect (void)
 
 static const char settings_dlg[] =
     "property \"Refresh interval (ms): \"       spinbtn[10,1000,1] "        CONFSTR_MS_REFRESH_INTERVAL         " 25 ;\n"
-    "property \"Number of bars: \"              spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 126 ;\n"
+    "property \"Number of bars: \"              spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 131 ;\n"
+    "property \"Bar width (0 - auto):               \"     spinbtn[0,10,1] "           CONFSTR_MS_BAR_W                    " 1 ;\n"
     "property \"Gap between bars  \"            checkbox "                  CONFSTR_MS_GAPS                     " 1 ;\n"
     "property \"Bar falloff (dB/s): \"          spinbtn[-1,1000,1] "        CONFSTR_MS_BAR_FALLOFF              " -1 ;\n"
     "property \"Bar delay (ms): \"              spinbtn[0,10000,100] "      CONFSTR_MS_BAR_DELAY                " 0 ;\n"

--- a/spectrum.c
+++ b/spectrum.c
@@ -510,7 +510,7 @@ spectrum_motion_notify_event (GtkWidget *widget, GdkEventButton *event, gpointer
 
     if (event->x > left && event->x < left + barw * CONFIG_NUM_BARS) {
         int pos = CLAMP ((int)((event->x-1-left)/barw),0,CONFIG_NUM_BARS-1);
-        int npos = ftoi( pos * 131 / CONFIG_NUM_BARS );
+        int npos = ftoi( pos * 132 / CONFIG_NUM_BARS );
         char tooltip_text[20];
         snprintf (tooltip_text, sizeof (tooltip_text), "%5.0f Hz (%s)", w->freq[pos], notes[npos]);
         gtk_widget_set_tooltip_text (widget, tooltip_text);
@@ -677,7 +677,7 @@ musical_spectrum_disconnect (void)
 
 static const char settings_dlg[] =
     "property \"Refresh interval (ms): \"       spinbtn[10,1000,1] "        CONFSTR_MS_REFRESH_INTERVAL         " 25 ;\n"
-    "property \"Number of bars: \"              spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 131 ;\n"
+    "property \"Number of bars: \"              spinbtn[2,2000,1] "         CONFSTR_MS_NUM_BARS                 " 132 ;\n"
     "property \"Bar width (0 - auto):               \"     spinbtn[0,10,1] "           CONFSTR_MS_BAR_W                    " 1 ;\n"
     "property \"Gap between bars  \"            checkbox "                  CONFSTR_MS_GAPS                     " 1 ;\n"
     "property \"Bar falloff (dB/s): \"          spinbtn[-1,1000,1] "        CONFSTR_MS_BAR_FALLOFF              " -1 ;\n"

--- a/spectrum.c
+++ b/spectrum.c
@@ -263,10 +263,14 @@ spectrum_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data) {
     if (!w->samples) {
         return FALSE;
     }
-    create_frequency_table(w);
 
     GtkAllocation a;
     gtk_widget_get_allocation (w->drawarea, &a);
+
+    static int last_bar_w = 1000;
+    if (a.width != last_bar_w)
+        create_frequency_table(w);
+    last_bar_w = a.width;
 
     const int bands = CONFIG_NUM_BARS;
     const int width = a.width;
@@ -358,7 +362,7 @@ spectrum_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data) {
     memset (data, 0, a.height * stride);
 
     int barw;
-    if (CONFIG_GAPS)
+    if (CONFIG_GAPS || CONFIG_BAR_W > 1)
         barw = CLAMP (width / bands, 2, 20);
     else
         barw = CLAMP (width / bands, 2, 20) - 1;

--- a/utils.c
+++ b/utils.c
@@ -139,7 +139,7 @@ create_frequency_table (gpointer user_data)
     if (CONFIG_NUM_BARS > MAX_BARS)
         CONFIG_NUM_BARS = MAX_BARS;
 
-    double ratio = CONFIG_NUM_BARS / 131.0;
+    double ratio = CONFIG_NUM_BARS / 132.0;
     double a4pos = 57.0 * ratio;
     double octave = 12.0 * ratio;
 

--- a/utils.c
+++ b/utils.c
@@ -34,6 +34,7 @@
 #include "fastftoi.h"
 #include "config.h"
 #include "spectrum.h"
+#include "utils.h"
 
 void
 _memset_pattern (char *data, const void* pattern, size_t data_len, size_t pattern_len)
@@ -124,10 +125,21 @@ void
 create_frequency_table (gpointer user_data)
 {
     w_spectrum_t *w = user_data;
-
     w->low_res_end = 0;
 
-    double ratio = CONFIG_NUM_BARS / 126.0;
+    GtkAllocation a;
+    gtk_widget_get_allocation (w->drawarea, &a);
+
+    if (CONFIG_BAR_W > 0) {
+        int added_bar_w = CONFIG_BAR_W;
+        if (CONFIG_GAPS)
+            added_bar_w += 1;
+        CONFIG_NUM_BARS = a.width/added_bar_w;
+    }
+    if (CONFIG_NUM_BARS > MAX_BARS)
+        CONFIG_NUM_BARS = MAX_BARS;
+
+    double ratio = CONFIG_NUM_BARS / 131.0;
     double a4pos = 57.0 * ratio;
     double octave = 12.0 * ratio;
 


### PR DESCRIPTION
Added "Bar width" option to the preferences window. When set to 0, width is adjusted according to the number of bars specified. If bar width is set to something other than 0, number of bars is adjusted dynamically to fit into the drawing area.

For some reason, when gaps between bars are disabled and bar width is > 1, the resulting bars are often narrower than the drawing area. When gaps are enabled, the picture is fine at any bar width setting. When bar width is 1 and gaps are disabled, everything is fine as well.