### PR TITLE
Fix transient-for for popup menu and config dialog

### DIFF
--- a/config_dialog.c
+++ b/config_dialog.c
@@ -263,6 +263,7 @@ on_button_config (GtkMenuItem *menuitem, gpointer user_data)
     GtkWidget *cancelbutton1;
     GtkWidget *okbutton1;
     spectrum_properties = gtk_dialog_new ();
+    gtk_window_set_transient_for (GTK_WINDOW (spectrum_properties), gtk_widget_get_toplevel (menuitem));
     gtk_window_set_title (GTK_WINDOW (spectrum_properties), "Spectrum Properties");
     gtk_window_set_type_hint (GTK_WINDOW (spectrum_properties), GDK_WINDOW_TYPE_HINT_DIALOG);
     gtk_window_set_resizable (GTK_WINDOW (spectrum_properties), FALSE);

--- a/spectrum.c
+++ b/spectrum.c
@@ -831,6 +831,7 @@ w_musical_spectrum_create (void) {
     w->base.message = spectrum_message;
     w->drawarea = gtk_drawing_area_new ();
     w->popup = gtk_menu_new ();
+    gtk_menu_attach_to_widget (GTK_MENU (w->popup), w->base.widget, NULL);
     w->popup_item = gtk_menu_item_new_with_mnemonic ("Configure");
     w->mutex = deadbeef->mutex_create ();
 


### PR DESCRIPTION
Gtk3 requires this to properly position popup menus on Wayland.
